### PR TITLE
Dynamically determine available cores and mem

### DIFF
--- a/bin/init_script.sh
+++ b/bin/init_script.sh
@@ -4,8 +4,8 @@
 exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
 VOLUME_ID=vol-09e8d020c214c9d33
-RESERVED_CORES=1
-RESERVED_MEM_MB=1024
+RESERVED_CORES=2
+RESERVED_MEM_MB=6144
 
 sudo apt update
 sudo apt install -y software-properties-common git

--- a/bin/init_script.sh
+++ b/bin/init_script.sh
@@ -4,6 +4,8 @@
 exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
 VOLUME_ID=vol-09e8d020c214c9d33
+RESERVED_CORES=1
+RESERVED_MEM_MB=1024
 
 sudo apt update
 sudo apt install -y software-properties-common git
@@ -15,4 +17,4 @@ cd galaxy-k8s-boot
 
 sed -i "s|extra_server_args=\"--tls-san localhost --disable traefik --v=4\"|extra_server_args=\"--tls-san $(curl -s http://169.254.169.254/latest/meta-data/public-ipv4) --disable traefik --v=4\"|" inventories/localhost
 
-ansible-playbook -i inventories/localhost playbook.yml --extra-vars "kube_cloud_provider=aws" --extra-vars "ebs_volume_id=$VOLUME_ID" --extra-vars "job_max_cores=1" --extra-vars "job_max_mem=4"
+ansible-playbook -i inventories/localhost playbook.yml --extra-vars "kube_cloud_provider=aws" --extra-vars "ebs_volume_id=$VOLUME_ID" --extra-vars "job_max_cores=$(($(nproc) - $RESERVED_CORES))" --extra-vars "job_max_mem=$(( $(free -m | awk '/^Mem:/{print $2}') - $RESERVED_MEM_MB ))"


### PR DESCRIPTION
We could potentially use
```
  --extra-vars "job_max_cores=$(($(grep -c '^processor' /proc/cpuinfo) - $RESERVED_CORES))" \
  --extra-vars "job_max_mem=$(( $(awk '/^MemTotal:/{print int($2/1024)}' /proc/meminfo) - $RESERVED_MEM_MB ))"
```
for even greater portability, but `nproc` and `free` are available on most debian distributions with coreutils installed.